### PR TITLE
Updated util/ensure_sim.py with available version

### DIFF
--- a/util/ensure_sim.py
+++ b/util/ensure_sim.py
@@ -132,7 +132,7 @@ def get_latest_sim_url():
     sim_prefix = 'sim/' + c.SIM_PREFIX
     conn = S3Connection(anon=True)
     bucket = conn.get_bucket('deepdrive')
-    bucket_search_str = sim_prefix + '-' + c.MAJOR_MINOR_VERSION_STR
+    bucket_search_str = sim_prefix + '-' + '2.0' #c.MAJOR_MINOR_VERSION_STR
     sim_versions = list(bucket.list(bucket_search_str))
     if not sim_versions:
         raise RuntimeError('Could not find a sim version matching %s '


### PR DESCRIPTION
In windows there was the issue of simulator version not available in the amazon S3 bucket so I replaced the version with available version 2.0 in get_latest_sim_url() function to get it working.I have commented the c.MAJOR_MINOR_VERSION_STR so that when latest version is uploaded to amazon bucket it can be un commented to use the latest version.